### PR TITLE
Make mbAlbumId not required in AlbumCard.jsx (because it is not always present)

### DIFF
--- a/frontend/src/Main/AlbumCard.jsx
+++ b/frontend/src/Main/AlbumCard.jsx
@@ -58,7 +58,7 @@ AlbumCard.propTypes = {
       imageKey: PropTypes.string,
     }),
     mbAlbum: PropTypes.shape({
-      mbAlbumId: PropTypes.string.isRequired,
+      mbAlbumId: PropTypes.string,
     }),
   }).isRequired,
 };


### PR DESCRIPTION
Closes #96.