### PR TITLE
Convert the `release_date` column of the `mb_candidates` table to type `DATE`

### DIFF
--- a/backend/migrations/20251024153750_create_mb_candidates_table.ts
+++ b/backend/migrations/20251024153750_create_mb_candidates_table.ts
@@ -9,7 +9,7 @@ export function up(knex: Knex): Promise<void> {
         CHECK (length(album_id) = 36),
       score INTEGER,
       track_count INTEGER,
-      release_date TIMESTAMPTZ,
+      release_date DATE,
       mb_candidate_album_name TEXT NOT NULL,
       mb_candidate_artists TEXT NOT NULL,
       mb_candidate_tracks TEXT NOT NULL,


### PR DESCRIPTION
Closes #461.